### PR TITLE
Fix English Locale Unknown Key Error

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -4,6 +4,7 @@ niobium=Niobium ore
 
 [autoplace-control-names]
 niobium=Niobium
+borax=Borax
 
 [item-group-name]
 coal-processing=Coal Processing


### PR DESCRIPTION
The Borax autoplace-control-name key is missing, thus generating an
Unknown Key error in the Resource Allocation UI. This fixes that.